### PR TITLE
Problems with INFO file + metadef

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+
+gem "sinatra", "~> 1.0"
+gem "rack-test", "~> 0.6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,20 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    rack (1.4.1)
+    rack-protection (1.2.0)
+      rack
+    rack-test (0.6.1)
+      rack (>= 1.0)
+    sinatra (1.3.2)
+      rack (~> 1.3, >= 1.3.6)
+      rack-protection (~> 1.2)
+      tilt (~> 1.3, >= 1.3.3)
+    tilt (1.3.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rack-test (~> 0.6.1)
+  sinatra (~> 1.0)

--- a/INFO
+++ b/INFO
@@ -9,5 +9,5 @@
 :email: email@hallisonbatista.com
 :homepage: http://sinatra-mapping.rubyforge.org/
 :dependencies:
-  sinatra: >= 0.9.1.1
+  sinatra: ">= 0.9.1.1"
 

--- a/Rakefile
+++ b/Rakefile
@@ -67,3 +67,4 @@ Rake::RDocTask.new("doc:api") do |rdoc|
   }
 end
 
+task :default => :test

--- a/lib/sinatra/mapping.rb
+++ b/lib/sinatra/mapping.rb
@@ -28,12 +28,12 @@ module Mapping
     @locations ||= {}
     if name.to_sym == :root
       @locations[:root] = cleanup_paths("/#{path}/")
-      metadef "#{name}_path" do |*paths|
+      define_method "#{name}_path" do |*paths|
         cleanup_paths("/#{@locations[:root]}/?")
       end
     else
       @locations[name.to_sym] = cleanup_paths(path || name.to_s)
-      metadef "#{name}_path" do |*paths|
+      define_method "#{name}_path" do |*paths|
         map_path_to(@locations[name.to_sym], *paths << "/?")
       end
     end


### PR DESCRIPTION
There were two problems, just to use it in my personal project.
First thing was related to the facts that the `metadef` were used instead of `define_method` as it was claimed by Sinatra guys( here is the thread https://github.com/sinatra/sinatra/issues/491).
Second thing is that Psyco (Yaml engine in Ruby, that is used by default by Bundler 1.0.10), did not wanted to play nicely with INFO file.
